### PR TITLE
fix: resnet101 incorrectly calling resnet34 in build_resnet

### DIFF
--- a/yolo/models/yolov1/resnet.py
+++ b/yolo/models/yolov1/resnet.py
@@ -101,7 +101,7 @@ def build_resnet(model_name="resnet18", pretrained=False):
         model = resnet50(pretrained)
         feat_dim = 2048
     elif model_name == 'resnet101':
-        model = resnet34(pretrained)
+        model = resnet101(pretrained)
         feat_dim = 2048
     else:
         raise NotImplementedError("Unknown resnet: {}".format(model_name))


### PR DESCRIPTION
## Bug Fix
In `build_resnet()`, the `resnet101` branch was calling `resnet34()` instead of `resnet101()`.
This caused the wrong model architecture to be loaded when `model_name='resnet101'` was specified,despite `feat_dim` being correctly set to 2048.

## Changes
- `yolo/models/yolov1/resnet.py`: Replace `resnet34(pretrained)` with `resnet101(pretrained)` in the `resnet101` branch